### PR TITLE
improved nat-rule identify and removal

### DIFF
--- a/natanator.sh
+++ b/natanator.sh
@@ -2,6 +2,22 @@
 
 while true
 do
-    iptables -t nat -F POSTROUTING
+    # identify MASQUERADE jump target in UBIOS_POSTROUTING_USER_HOOK chain
+    # which will be added per default for UBIOS_ADDRv4_ethX (eth8/eth9) to
+    # manage NAT throught WAN
+    rules=$(/usr/sbin/iptables -t nat -L UBIOS_POSTROUTING_USER_HOOK --line-numbers | \
+                grep "MASQUERADE .* UBIOS_ADDRv4_eth. src" | \
+                cut -d' ' -f1)
+
+    # for each rule identified we issue a delete operation in reverse
+    # order so that UBIOS_POSTROUTINE_USER_HOOK will really only contain
+    # NAT rules a user manually defined in the Network UI.
+    for rulenum in $(echo ${rules} | rev); do
+        /usr/sbin/iptables -t nat -D UBIOS_POSTROUTING_USER_HOOK ${rulenum}
+    done
+
+    # sleep for one minute and then
+    # re-evaluate because changed in the Network UI
+    # could reintroduce the NAT/MASQUERADE rules
     sleep 60
 done


### PR DESCRIPTION
This change modifies identification and removal of the acqual global NAT WAN rules for a UniFiOS environment. In fact, instead of completely flushing the whole POSTROUTING chain to get rid of NAT, this change modifies natanator.sh to just remove the actual MASQUERADE jump targets under the UBIOS_POSTROUTING_USER_HOOK chain where UniFiOS actually places the global NAT WAN rules.
In addition, this change makes also sure that user defined NAT rules will stay effective, thus just the global anywhere/anywhere NAT rules with reference to UBIOS_ADDRv4_eth8 and UBIOS_ADDRv4_eth9 will be removed. Thus, user defined NAT rules will still continue to work while only NAT WAN rules will be removed to make sure no double NAT will be effective if a dedicated router is doing the NAT and e.g. a UDMpro should only work as a plain network client and refrain from doing NAT itself.