### PR TITLE
integrated regex fix for unifios-3.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Login to your UniFiOS device (e.g. UDM-pro) using ssh and perform the following 
 
 1. Download and install the `natanator.sh` script directly on your UniFiOS device via:
    ```sh
-   wget -O /usr/local/bin/natanator.sh https://raw.githubusercontent.com/jadedeane/natanator/main/natanator.s
+   wget -O /usr/local/bin/natanator.sh https://raw.githubusercontent.com/jadedeane/natanator/main/natanator.sh
    chmod +x /usr/local/bin/natanator.sh
    ```
 

--- a/natanator.sh
+++ b/natanator.sh
@@ -6,7 +6,7 @@ do
     # which will be added per default for UBIOS_ADDRv4_ethX (eth8/eth9) to
     # manage NAT throught WAN
     rules=$(/usr/sbin/iptables -t nat -L UBIOS_POSTROUTING_USER_HOOK --line-numbers | \
-                grep "MASQUERADE .* UBIOS_ADDRv4_eth. src" | \
+                grep "MASQUERADE .* UBIOS_.*ADDRv4_eth. src" | \
                 cut -d' ' -f1)
 
     # for each rule identified we issue a delete operation in reverse


### PR DESCRIPTION
This PR integrates a minor fix for the double NAT regex check which does not work with the latest UniFiOS 3.2.x version anymore since the corresponding NAT rules were renamed to `UBIOS_ALL_ADDRv4_eth` (i.e.g with `ALL` in the name). Thus, the adapted grep regex should catch these newer rule names with this PR.